### PR TITLE
メモリワークによる画面のフリーズを修正

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2062,7 +2062,7 @@ __webpack_require__.r(__webpack_exports__);
       jobs: []
     };
   },
-  mounted: function mounted() {
+  created: function created() {
     var self = this;
     var sessionParam = [];
 
@@ -2129,6 +2129,7 @@ __webpack_require__.r(__webpack_exports__);
       Object.keys(self.params.salary_child).forEach(function (key) {
         return self.params.salary_child[key] = "";
       });
+      self.salaries = [];
 
       if (self.params.salary == 284) {
         tmp_salaries = self.categories[3]["children"][0];

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/app.js": "/js/app.js?id=8846b271357e7347a434",
+    "/js/app.js": "/js/app.js?id=d4724354067a9f958b48",
     "/css/app.css": "/css/app.css?id=c1139e5d70a601385370",
     "/css/admin.css": "/css/admin.css?id=2f0d1d202b4790dbe9d3"
 }

--- a/resources/js/components/SearchComponent.vue
+++ b/resources/js/components/SearchComponent.vue
@@ -127,7 +127,7 @@ export default {
       jobs: []
     };
   },
-  mounted() {
+  created() {
     const self = this;
     let sessionParam = [];
 
@@ -192,6 +192,8 @@ export default {
       Object.keys(self.params.salary_child).forEach(
         key => (self.params.salary_child[key] = "")
       );
+
+      self.salaries = [];
 
       if (self.params.salary == 284) {
         tmp_salaries = self.categories[3]["children"][0];


### PR DESCRIPTION
When searching in production, the screen freezes when you select salary. Corrected assuming screen freeze due to memory work.