### PR TITLE
求人一覧に新着マークを実装

### DIFF
--- a/app/Models/JobItem.php
+++ b/app/Models/JobItem.php
@@ -104,6 +104,26 @@ class JobItem extends Model
         return $category->achievementReward()->exists() ? $category->achievementReward->amount : 0;
     }
 
+    public function isNew()
+    {
+        $target = '';
+
+        $sf = $this->pub_start_flag;
+        if ($sf) {
+            $target = $this->pub_start_date ?: '';
+        } else {
+            $target = $this->created_at;
+        }
+        if ($target) {
+            $target = new Carbon($target);
+            $targetEnd = $target->addDay(10);
+        }
+
+        $today = new Carbon();
+
+        return $target && $targetEnd > $today;
+    }
+
     public function getAppJobList(int $num_per_page = 10, array $condition = [])
     {
         // パラメータの取得

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -14079,11 +14079,11 @@ input {
 
 .cat-item {
   display: inline-block;
-  top: 0;
-  left: 0;
   padding: 3px 6px;
   color: #fff;
-  margin-right: 20px;
+  font-size: 14px;
+  margin-right: 10px;
+  border-radius: 3px;
 }
 
 .cat-item.org {
@@ -16570,10 +16570,12 @@ input[size="28"] {
   margin-left: 1em;
 }
 
-.job-entry .job-item-heading {
-  display: flex;
-  align-items: center;
-  margin-bottom: 1em;
+@media screen and (min-width: 768px) {
+  .job-entry .job-item-heading {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1em;
+  }
 }
 
 .job-entry .company_name_item {
@@ -16676,6 +16678,25 @@ input[size="28"] {
   top: -10px;
   text-align: center;
   display: inline-block;
+}
+
+.job-lst-ico.job-lst-ico-for-list,
+.job-detail-ico.job-lst-ico-for-list {
+  position: absolute;
+  left: -10px;
+}
+
+@media screen and (min-width: 768px) {
+  .job-lst-ico.job-lst-ico-for-list,
+  .job-detail-ico.job-lst-ico-for-list {
+    position: unset;
+    padding: 3px 6px;
+    margin-right: 10px;
+    font-size: 14px;
+    line-height: normal;
+    line-height: unset;
+    letter-spacing: 0.1rem;
+  }
 }
 
 @media screen and (min-width: 768px) {
@@ -17228,11 +17249,6 @@ section.cat-list-section {
 
   .invi-job-entry .pad {
     padding: 2em 1%;
-  }
-
-  .cat-item {
-    font-size: 2vw;
-    margin-right: 10px;
   }
 
   .entrybtn-field .apply-btn,

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
     "/js/adminApp.js": "/js/adminApp.js?id=09f0996f2d928206c603",
     "/js/app.js": "/js/app.js?id=911486cc1567cc6086bb",
-    "/css/app.css": "/css/app.css?id=c978e1e3573b33a3ac5e",
+    "/css/app.css": "/css/app.css?id=eeaf623198b24ccae971",
     "/css/adminApp.css": "/css/adminApp.css?id=7fec90df55a533c3838f"
 }

--- a/resources/sass/partial/_common.scss
+++ b/resources/sass/partial/_common.scss
@@ -1065,11 +1065,11 @@ input {
 
 .cat-item {
   display: inline-block;
-  top: 0;
-  left: 0;
   padding: 3px 6px;
   color: #fff;
-  margin-right: 20px;
+  font-size: 14px;
+  margin-right: 10px;
+  border-radius: 3px;
 }
 .cat-item.org {
   background: #de9610;

--- a/resources/sass/partial/_job.scss
+++ b/resources/sass/partial/_job.scss
@@ -133,9 +133,11 @@
   }
 
   .job-item-heading {
-    display: flex;
-    align-items: center;
-    margin-bottom: 1em;
+    @include mq(medium) {
+      display: flex;
+      align-items: center;
+      margin-bottom: 1em;
+    }
   }
   .company_name_item {
     font-size: 14px;
@@ -221,9 +223,22 @@
   padding-left: 5px;
   position: relative;
   top: -10px;
-
   text-align: center;
   display: inline-block;
+
+  &.job-lst-ico-for-list {
+    position: absolute;
+    left: -10px;
+    @include mq(medium) {
+      position: unset;
+      padding: 3px 6px;
+      margin-right: 10px;
+      font-size: 14px;
+      line-height: normal;
+      line-height: unset;
+      letter-spacing: 0.1rem;
+    }
+  }
   @include mq(medium) {
     font-size: 18px;
   }
@@ -706,10 +721,6 @@ section.cat-list-section {
 
   .invi-job-entry .pad {
     padding: 2em 1%;
-  }
-  .cat-item {
-    font-size: 2vw;
-    margin-right: 10px;
   }
 
   .entrybtn-field .apply-btn,

--- a/resources/views/front/jobs/history.blade.php
+++ b/resources/views/front/jobs/history.blade.php
@@ -34,11 +34,13 @@
           @if ($jobitems !== [])
           @foreach ($jobitems as $jobitem)
           <div class="job-item">
+
             <a href="{{ route('show.front.job_sheet.detail', $jobitem) }}" class="job-item-link">
-              <div class="job-item-heading only-pc">
+              <div class="job-item-heading">
                 <!-- カテゴリ -->
-                <span class="cat-item org">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
-                <span class="cat-item red">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
+                @if($jobitem->isNew() ) <span class="cat-item job-lst-ico job-lst-ico-for-list">NEW</span>@endif
+                <span class="cat-item org ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
+                <span class="cat-item red ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
               </div>
               <div class="jobCassette__header">
                 <div class="jobCassette__image_wrap only-sp">

--- a/resources/views/front/jobs/keeplist.blade.php
+++ b/resources/views/front/jobs/keeplist.blade.php
@@ -36,10 +36,11 @@
           @foreach ($jobitems as $jobitem)
           <div class="job-item">
             <a href="{{ route('show.front.job_sheet.detail', $jobitem) }}" class="job-item-link">
-              <div class="job-item-heading only-pc">
+              <div class="job-item-heading">
                 <!-- カテゴリ -->
-                <span class="cat-item org">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
-                <span class="cat-item red">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
+                @if($jobitem->isNew() ) <span class="cat-item job-lst-ico job-lst-ico-for-list">NEW</span>@endif
+                <span class="cat-item org ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
+                <span class="cat-item red ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
               </div>
               <div class="jobCassette__header">
                 <div class="jobCassette__image_wrap only-sp">

--- a/resources/views/front/jobs/search.blade.php
+++ b/resources/views/front/jobs/search.blade.php
@@ -50,7 +50,9 @@ if ($getJobUrlPrmList !== []) {
   <section class="main-section job-entry">
     <div class="inner">
       <div class="pad cf">
-        <h1 class="txt-h1">求人検索結果</h1>
+        <h1 class="txt-h1">
+          求人検索結果
+        </h1>
         <div class="d-flex mb-3 p-works-count-box">
           @if($jobitems->count() > 0)
           <p class="search-count"><span>{{ $jobitems->firstItem() }}件 〜 {{ $jobitems->lastItem() }}件を表示</span></p>
@@ -80,9 +82,10 @@ if ($getJobUrlPrmList !== []) {
           @foreach ($jobitems as $jobitem)
           <div class="job-item">
             <a href="{{ route('show.front.job_sheet.detail', [$jobitem]) }}" class="job-item-link">
-              <div class="job-item-heading only-pc">
-                <span class="cat-item org">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
-                <span class="cat-item red">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
+              <div class="job-item-heading">
+                @if($jobitem->isNew() ) <span class="job-lst-ico job-lst-ico-for-list">NEW</span>@endif
+                <span class="cat-item org ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : '' }}</span>
+                <span class="cat-item red ib-only-pc">{{ $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : '' }}</span>
               </div>
               <div class="jobCassette__header">
                 <div class="jobCassette__image_wrap only-sp">

--- a/resources/views/front/jobs/show.blade.php
+++ b/resources/views/front/jobs/show.blade.php
@@ -58,7 +58,7 @@ $jobjson = json_encode($jobitem);
 
       @endphp
       <h1 class="txt-h1">
-        @if($target && $targetEnd > $today ) <span class="job-lst-ico">NEW</span>@endif
+        @if($jobitem->isNew() ) <span class="job-lst-ico">NEW</span>@endif
         {{$jobitem->company->cname}}の求人情報 </h1> <!-- カテゴリ -->
       <span class="cat-item org ib-only-pc">{{$jobitem->categories()->wherePivot('ancestor_slug', 'type')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'type')->first()->name : ''}}</span>
       <span class="cat-item red ib-only-pc">{{$jobitem->categories()->wherePivot('ancestor_slug', 'status')->first() !== null ? $jobitem->categories()->wherePivot('ancestor_slug', 'status')->first()->name : ''}}</span>


### PR DESCRIPTION
## Issue
fixed #105 

## 内容
- [ ] 新着の判定のコードをbladeファイル内からJobItemモデル内に変更
- [ ] 求人検索結果、キープリスト、閲覧履歴の求人一覧に新着マークを実装（掲載してから10日間）

## 動作確認
- [ ] テスト未実装のため、ブラウザによるテスト
- [ ] 該当URL：
/job_sheet/search/all
/keeplist (求職者ログイン認証が必要)
/history