### PR TITLE
運営管理画面にお祝い金設定機能を実装

### DIFF
--- a/app/Http/Controllers/Admin/Setting/RewardController.php
+++ b/app/Http/Controllers/Admin/Setting/RewardController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Setting;
+
+use App\Models\CongratsMoney;
+use Illuminate\Http\Request;
+use App\Http\Requests\Admin\Setting\Reward\StoreRewardRequest;
+use App\Http\Requests\Admin\Setting\Reward\UpdateRewardRequest;
+use Illuminate\Support\Arr;
+use App\Repositories\CategoryRepository;
+use App\Http\Controllers\Controller;
+
+class RewardController extends Controller
+{
+    private $categoryRepository;
+
+    public function __construct(CategoryRepository $categoryRepository)
+    {
+        $this->categoryRepository = $categoryRepository;
+    }
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('admin.setting.reward.index', [
+            'rewards' => CongratsMoney::orderBy('amount', 'asc')->get()
+        ]);
+    }
+
+    /**
+     * Create the form for storing the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('admin.setting.reward.create', [
+            'categories' => $this->categoryRepository->getCategoriesByslug('status')
+        ]);
+    }
+
+    /**
+     * Store the resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreRewardRequest $request)
+    {
+        CongratsMoney::create($request->input('data.Reward'));
+        return redirect()->back()->with('status', '作成しました！');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show(int $id)
+    {
+        return view('admin.setting.reward.show', [
+            'reward' =>  CongratsMoney::find($id)
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(int $id)
+    {
+        return view('admin.setting.reward.edit', [
+            'reward' => CongratsMoney::find($id),
+            'categories' => $this->categoryRepository->getCategoriesByslug('status')
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateRewardRequest $request, int $id)
+    {
+        $reward = CongratsMoney::find($id);
+        $reward->update(Arr::except($request->input('data.Reward'), ['id']));
+
+        return redirect()->back()->with('status', '保存しました！');
+    }
+
+    /**
+     * Delete the specified resource in storage.
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(int $id)
+    {
+        $reward = CongratsMoney::find($id);
+        $status = 0;
+
+        // 紐ずくカテゴリが既に求人票と紐付いている場合はエラー返す
+        if ($reward->category->jobitems->isEmpty()) {
+            $reward->delete();
+            $message = '削除しました！';
+            $status = 1;
+        } else {
+            $message = '求人票と紐付いているため削除出来ません！';
+        }
+
+        return response()->json([
+            'message' => $message,
+            'status' => $status,
+        ]);
+    }
+}

--- a/app/Http/Requests/Admin/Setting/Reward/StoreRewardRequest.php
+++ b/app/Http/Requests/Admin/Setting/Reward/StoreRewardRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\Reward;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRewardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.Reward.amount' => 'required|numeric',
+            'data.Reward.category_id' => 'required|not_in:null|unique:congrats_monies,category_id|exists:categories,id',
+            'data.Reward.label' => 'nullable|string|max:191',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.Reward.amount' => '金額',
+            'data.Reward.category_id' => 'カテゴリ',
+            'data.Reward.label' => 'ラベル',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Setting/Reward/UpdateRewardRequest.php
+++ b/app/Http/Requests/Admin/Setting/Reward/UpdateRewardRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\Reward;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRewardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.Reward.amount' => 'required|numeric',
+            'data.Reward.category_id' => 'required|not_in:null|unique:congrats_monies,category_id,' . $this->data['Reward']['id'] . '|exists:categories,id',
+            'data.Reward.label' => 'nullable|string|max:191',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.Reward.amount' => '金額',
+            'data.Reward.category_id' => 'カテゴリ',
+            'data.Reward.label' => 'ラベル',
+        ];
+    }
+}

--- a/app/Models/CongratsMoney.php
+++ b/app/Models/CongratsMoney.php
@@ -28,7 +28,7 @@ class CongratsMoney extends Model
         return $this->belongsTo(Category::class);
     }
 
-    public function getCostomAmountAttribute()
+    public function getCustomAmountAttribute()
     {
         return number_format($this->amount) . "円";
     }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -272,7 +272,7 @@ return [
             'submenu' => [
                 [
                     'text' => 'お祝い金',
-                    'url'  => '#',
+                    'url'  => 'admin/setting/reward',
                 ],
                 [
                     'text' => '採用報酬',
@@ -367,7 +367,7 @@ return [
             ],
         ],
         'Sweetalert2' => [
-            'active' => false,
+            'active' => true,
             'files' => [
                 [
                     'type' => 'js',

--- a/resources/views/admin/setting/reward/create.blade.php
+++ b/resources/views/admin/setting/reward/create.blade.php
@@ -1,0 +1,93 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | お祝い金設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>お祝い金設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('reward.index') }}">お祝い金設定</a></li>
+<li class="breadcrumb-item active">編集</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">作成</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('reward.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('reward.store') }}" method="POST" accept-charset="UTF-8">
+                    @csrf
+                    @if(count($errors) > 0)
+                    <div class="alert alert-danger">
+                        <strong><i class="fas fa-exclamation-circle"></i>エラー</strong><br>
+                        <ul class="list-unstyled">
+                            @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endif
+                    <div class="body-box">
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">金額</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="amount" name="data[Reward][amount]" class="form-control" value="{{ old('data.Reward.amount') }}" placeholder="入力　金額" required><span class="mt-1 ml-2">円</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <select class="custom-select" name="data[Reward][category_id]" required>
+                                            <option value="">選択</option>
+                                            @foreach($categories as $category)
+                                            <option value="{{ $category->id }}" @if(old('data.Reward.category_id')===(string) $category->id){{ 'selected' }}@endif>{{ $category->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">ラベル</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="label" name="data[Reward][label]" class="form-control" value="{{ old('data.Reward.label') }}" placeholder="入力　ラベル">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-2">
+                            </div>
+                            <div class="col-md-8 text-right">
+                                <div class="btn-group">
+                                    <button id="admin-submit" type="submit" class="btn btn-primary">作成</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@stop

--- a/resources/views/admin/setting/reward/edit.blade.php
+++ b/resources/views/admin/setting/reward/edit.blade.php
@@ -1,13 +1,13 @@
 @extends('adminlte::page')
 
-@section('title', 'JOB CiNEMA | お祝い金管理')
+@section('title', 'JOB CiNEMA | お祝い金設定')
 
 @section('content_header')
-<h1><i class="fas fa-edit mr-2"></i>お祝い金管理</h1>
+<h1><i class="fas fa-edit mr-2"></i>お祝い金設定</h1>
 @stop
 
 @section('content_bread')
-<li class="breadcrumb-item"><a href="{{ route('reward.index') }}">お祝い金管理</a></li>
+<li class="breadcrumb-item"><a href="{{ route('reward.index') }}">お祝い金設定</a></li>
 <li class="breadcrumb-item active">編集</li>
 @stop
 
@@ -28,6 +28,11 @@
                             <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
                         </a>
                     </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $reward->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
                 </div>
             </div>
             <div class="card-body">
@@ -45,15 +50,11 @@
                                     <p class="system-values-item">{{ $reward->id }}</p>
                                 </li>
                                 <li>
-                                    <p class="system-values-label">応募者</p>
-                                    <p class="system-values-item"><a href="javascript:void(0);" data-toggle="tooltip" title="データ確認"><span class="d-inline-block">#{{ $reward->user_id ?: '退会済み'}}<br>{{ $reward->user->full_name }}</span></a></p>
+                                    <p class="system-values-label">作成日時</p>
+                                    <p class="system-values-item">{{ $reward->created_at }}</p>
                                 </li>
                                 <li>
-                                    <p class="system-values-label">応募データ</p>
-                                    <p class="system-values-item"><a href="javascript:void(0);" data-toggle="tooltip" title="データ確認"><span class="d-inline-block">#{{ $reward->apply->id }}</span></a></p>
-                                </li>
-                                <li>
-                                    <p class="system-values-label">申請日</p>
+                                    <p class="system-values-label">更新日時</p>
                                     <p class="system-values-item">{{ $reward->created_at }}</p>
                                 </li>
                             </ul>
@@ -73,12 +74,22 @@
                     <div class="body-box">
                         <div class="form-group">
                             <div class="row">
-                                <label class="col-sm-2 text-sm-right">ステータス</label>
+                                <label class="col-sm-2 text-sm-right">金額</label>
                                 <div class="col-sm-8">
                                     <div class="input-group">
-                                        <select class="custom-select" name="data[Reward][status]" required="1">
-                                            @foreach(config('const.CONGRAT_PAYMENT_STATUS') as $key => $value)
-                                            <option value="{{ $key }}" @if(old('data.Reward.status')===(string) $key){{ 'selected' }}@else{{ !old('data.Reward.status') && old('data.Reward.status') !== '0' && $key === $reward->status ? 'selected' : ''}}@endif>{{ $value }}</option>
+                                        <input type="text" id="amount" name="data[Reward][amount]" class="form-control" value="@if(old('data.Reward.amount')){{ old('data.Reward.amount') }}@else{{ $reward->amount ? $reward->amount : '' }}@endif" placeholder="入力　金額" required><span class="mt-1 ml-2">円</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <select class="custom-select" name="data[Reward][category_id]" required>
+                                            @foreach($categories as $category)
+                                            <option value="{{ $category->id }}" @if(old('data.Reward.category_id')===(string) $category->id){{ 'selected' }}@else{{ !old('data.Reward.category_id') && old('data.Reward.category_id') !== '0' && $category->id === $reward->category_id ? 'selected' : ''}}@endif>{{ $category->name }}</option>
                                             @endforeach
                                         </select>
                                     </div>
@@ -86,22 +97,13 @@
                             </div>
                         </div>
                     </div>
+
                     <div class="form-group">
                         <div class="row">
-                            <label class="col-sm-2 text-sm-right">金額</label>
+                            <label class="col-sm-2 text-sm-right">ラベル</label>
                             <div class="col-sm-8">
                                 <div class="input-group">
-                                    <input type="text" id="billing_amount" name="data[Reward][billing_amount]" class="form-control" value="@if(old('data.Reward.billing_amount')){{ old('data.Reward.billing_amount') }}@else{{ $reward->billing_amount ? $reward->billing_amount : '' }}@endif" placeholder="入力　金額"><span class="mt-1 ml-2">円</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div class="row">
-                            <label class="col-sm-2 text-sm-right">支払日</label>
-                            <div class="col-sm-8">
-                                <div class="input-group">
-                                    <input type="text" id="payment_date" name="data[Reward][payment_date]" class="form-control" value="@if(old('data.Reward.payment_date')){{ old('data.Reward.payment_date') }}@else{{ $reward->payment_date ?  $reward->payment_date->format('Y-m-d H:i'): '' }}@endif" placeholder="入力　支払日">
+                                    <input type="text" id="label" name="data[Reward][label]" class="form-control" value="@if(old('data.Reward.label')){{ old('data.Reward.label') }}@else{{ $reward->label ?: '' }}@endif" placeholder="入力　ラベル">
                                 </div>
                             </div>
                         </div>
@@ -125,9 +127,10 @@
 @section('js')
 <script>
     $(function() {
-        $('#payment_date').datetimepicker({
-            format: 'Y-m-d H:i'
+        $('.{{$reward->id}}-delete').click(function(event) {
+            deleteItem('/admin/setting/reward/', '{{$reward->id}}', '/admin/setting/reward');
         });
+
     });
 </script>
 @stop

--- a/resources/views/admin/setting/reward/index.blade.php
+++ b/resources/views/admin/setting/reward/index.blade.php
@@ -1,13 +1,13 @@
 @extends('adminlte::page')
 
-@section('title', 'JOB CiNEMA | お祝い金管理')
+@section('title', 'JOB CiNEMA | お祝い金設定')
 
 @section('content_header')
-<h1><i class="fas fa-home mr-2"></i>お祝い金管理</h1>
+<h1><i class="fas fa-home mr-2"></i>お祝い金設定</h1>
 @stop
 
 @section('content_bread')
-<li class="breadcrumb-item active">お祝い金管理</li>
+<li class="breadcrumb-item active">お祝い金設定</li>
 @stop
 
 @section('content')
@@ -15,117 +15,21 @@
     <div class="col-12">
         <div class="card">
             <div class="card-header with-border">
-                <div class="btn-group">
-                    <button type="button" class="btn btn-primary btn-flat filter-btn">フィルター</button>
-                </div>
-                <div class="mt-4 mb-3" id="filter-box">
-                    <form action="{{ route('reward.index') }}" method="get">
-                        <div class="row">
-                            <div class="col-12">
-                                <div class="fields-group">
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">応募者ID</label>
-                                        <div class="col-xl-9">
-                                            <div class="input-group input-group-sm">
-                                                <div class="input-group-addon">
-                                                    <i class="fa fa-pencil"></i>
-                                                </div>
-                                                <input type="text" class="form-control" placeholder="応募者ID" name="user_id" value="{{ $param['user_id'] ?? '' }}">
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">応募ID</label>
-                                        <div class="col-xl-9">
-                                            <div class="input-group input-group-sm">
-                                                <div class="input-group-addon">
-                                                    <i class="fa fa-pencil"></i>
-                                                </div>
-                                                <input type="text" class="form-control" placeholder="応募ID" name="apply_id" value="{{ $param['apply_id'] ?? '' }}">
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">申請日</label>
-                                        <div class="input-group col-xl-9">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text">
-                                                    <i class="far fa-calendar-alt"></i>
-                                                </span>
-                                            </div>
-                                            <input type="text" class="form-control" id="created_at_start" placeholder="申請日" name="created_at[start]" value="{{ $param['created_at']['start'] ?? '' }}">
-                                            <span class="input-group-text rounded-0 bg-white" style="border-left: 0; border-right: 0;">-</span>
-                                            <input type="text" class="form-control" id="created_at_end" placeholder="申請日" name="created_at[end]" value="{{ $param['created_at']['end'] ?? '' }}">
-                                        </div>
-                                    </div>
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">ステータス</label>
-                                        <div class="col-xl-9">
-                                            <div class="input-group">
-                                                <select class="form-control select-box" name="status">
-                                                    <option value="">未選択</option>
-                                                    @foreach(config('const.CONGRAT_PAYMENT_STATUS') as $key => $value)
-                                                    <option value="{{ $key }}" {{ array_key_exists('status', $param) && isset($param['status']) && $param['status'] === (string) $key ? 'selected' : '' }}>{{ $value }}</option>
-                                                    @endforeach
-                                                </select>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">金額</label>
-                                        <div class="col-xl-9">
-                                            <div class="input-group input-group-sm">
-                                                <div class="input-group-addon">
-                                                    <i class="fa fa-pencil"></i>
-                                                </div>
-                                                <input type="text" class="form-control" placeholder="金額" name="billing_amount" value="{{ $param['billing_amount'] ?? '' }}">
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group row">
-                                        <label class="col-xl-2 col-form-label">支払日</label>
-                                        <div class="input-group col-xl-9">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text">
-                                                    <i class="far fa-calendar-alt"></i>
-                                                </span>
-                                            </div>
-                                            <input type="text" class="form-control" id="payment_date_start" placeholder="支払日" name="payment_date[start]" value="{{ $param['payment_date']['start'] ?? '' }}">
-                                            <span class="input-group-text rounded-0 bg-white" style="border-left: 0; border-right: 0;">-</span>
-                                            <input type="text" class="form-control" id="payment_date_end" placeholder="支払日" name="payment_date[end]" value="{{ $param['payment_date']['end'] ?? '' }}">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="row">
-                                    <div class="col-md-2"></div>
-                                    <div class="col-md-8">
-                                        <div class="btn-group pull-left">
-                                            <button class="btn btn-info submit btn-sm"><i class="fa fa-search"></i>&nbsp;&nbsp;サーチ</button>
-                                        </div>
-                                        <div class="btn-group pull-left " style="margin-left: 10px;">
-                                            <a href="{{ route('reward.index') }}" class="btn btn-secondary btn-sm"><i class="fa fa-undo"></i>&nbsp;&nbsp;リセット</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </form>
+                <div class="btn-group float-right">
+                    <a href="{{ route('reward.create') }}" class="btn btn-sm btn-success">
+                        <i class="fa fa-plus"></i><span class="hidden-xs">&nbsp;&nbsp;新規</span>
+                    </a>
                 </div>
             </div>
             <div class="card-body">
                 <table id="tableReward" class="table table-bordered">
                     <thead>
                         <tr>
-                            <th class="nosort">ID</th>
-                            <th>申請日</th>
-                            <th>ステータス</th>
+                            <th>ID</th>
                             <th>金額</th>
-                            <th>支払日</th>
-                            <th class="nosort">操作</th>
+                            <th>カテゴリ</th>
+                            <th>ラベル</th>
+                            <th>操作</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -133,10 +37,9 @@
                         @foreach($rewards as $reward)
                         <tr>
                             <td>{{ $reward->id }}</td>
-                            <td>{{ $reward->created_at }}</td>
-                            <td>{{ config('const.CONGRAT_PAYMENT_STATUS.' . $reward->status) }}</td>
                             <td>{{ $reward->custom_amount }}</td>
-                            <td>{{ $reward->payment_date ? $reward->payment_date->format('Y-m-d H:i') : '未払い' }}</td>
+                            <td>{{ $reward->category->name }}</td>
+                            <td>{{ $reward->label }}</td>
                             <td class="project-actions text-right">
                                 <a class="btn btn-primary btn-sm" href="{{ route('reward.show', $reward->id) }}">
                                     <i class="fas fa-eye">
@@ -145,6 +48,9 @@
                                 <a class="btn btn-info btn-sm" href="{{ route('reward.edit', $reward->id) }}">
                                     <i class="fas fa-pencil-alt">
                                     </i>
+                                </a>
+                                <a href="javascript:void(0);" class="btn btn-danger btn-sm grid-row-delete" data-id="{{ $reward->id }}" data-toggle="tooltip" title="" data-original-title="削除">
+                                    <i class="fa fa-trash"></i>
                                 </a>
                             </td>
                         </tr>
@@ -164,36 +70,11 @@
 @section('js')
 <script>
     $(function() {
-        $('#created_at_start').datepicker({
-            format: 'yyyy-mm-dd',
-            language: 'ja'
-        }).on("changeDate", function(e) {
-            $('#created_at_end').datepicker('setStartDate', e.date);
-        });
-        $('#created_at_end').datepicker({
-            format: 'yyyy-mm-dd',
-            language: 'ja'
-        }).on("changeDate", function(e) {
-            $('#created_at_start').datepicker('setEndDate', e.date);
-        });
-        $('#payment_date_start').datepicker({
-            format: 'yyyy-mm-dd',
-            language: 'ja'
-        }).on("changeDate", function(e) {
-            $('#payment_date_end').datepicker('setStartDate', e.date);
-        });
-        $('#payment_date_end').datepicker({
-            format: 'yyyy-mm-dd',
-            language: 'ja'
-        }).on("changeDate", function(e) {
-            $('#payment_date_start').datepicker('setEndDate', e.date);
-        });
-
-        tableJobItem = $('#tableReward').DataTable({
+        $('#tableReward').DataTable({
             "paging": true,
             "searching": true,
             "scrollX": true,
-            "ordering": true,
+            "ordering": false,
             "lengthMenu": [10, 20, 30, 40, 50, 100],
             "displayLength": 50,
             "info": true,
@@ -205,6 +86,10 @@
             }]
         });
 
+        $('.grid-row-delete').unbind('click').click(function() {
+            let id = $(this).data('id');
+            deleteItem('/admin/setting/reward/', id, '/admin/setting/reward');
+        });
 
     });
 </script>

--- a/resources/views/admin/setting/reward/show.blade.php
+++ b/resources/views/admin/setting/reward/show.blade.php
@@ -1,13 +1,13 @@
 @extends('adminlte::page')
 
-@section('title', 'JOB CiNEMA | お祝い金管理')
+@section('title', 'JOB CiNEMA | お祝い金設定')
 
 @section('content_header')
-<h1><i class="fas fa-edit mr-2"></i>お祝い金管理</h1>
+<h1><i class="fas fa-edit mr-2"></i>お祝い金設定</h1>
 @stop
 
 @section('content_bread')
-<li class="breadcrumb-item"><a href="{{ route('reward.index') }}">お祝い金管理</a></li>
+<li class="breadcrumb-item"><a href="{{ route('reward.index') }}">お祝い金設定</a></li>
 <li class="breadcrumb-item active">詳細</li>
 @stop
 
@@ -28,6 +28,11 @@
                             <i class="fa fa-edit"></i><span class="hidden-xs"> 編集</span>
                         </a>
                     </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $reward->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
                 </div>
             </div>
             <div class="card-body">
@@ -41,15 +46,11 @@
                                 <p class="system-values-item">{{ $reward->id }}</p>
                             </li>
                             <li>
-                                <p class="system-values-label">応募者</p>
-                                <p class="system-values-item"><a href="javascript:void(0);" data-toggle="tooltip" title="データ確認"><span class="d-inline-block">#{{ $reward->user_id ?: '退会済み'}}<br>{{ $reward->user->full_name }}</span></a></p>
+                                <p class="system-values-label">作成日時</p>
+                                <p class="system-values-item">{{ $reward->created_at }}</p>
                             </li>
                             <li>
-                                <p class="system-values-label">応募データ</p>
-                                <p class="system-values-item"><a href="javascript:void(0);" data-toggle="tooltip" title="データ確認"><span class="d-inline-block">#{{ $reward->apply->id }}</span></a></p>
-                            </li>
-                            <li>
-                                <p class="system-values-label">申請日</p>
+                                <p class="system-values-label">更新日時</p>
                                 <p class="system-values-item">{{ $reward->created_at }}</p>
                             </li>
                         </ul>
@@ -59,21 +60,22 @@
                 <div class="body-box">
                     <div class="form-group">
                         <div class="row">
-                            <label class="col-sm-2 text-sm-right">ステータス</label>
-                            <div class="col-sm-8">
-                                <p>{{ config('const.CONGRAT_PAYMENT_STATUS.' . $reward->status) }}</p>
-                            </div>
-                        </div>
-                        <div class="row">
                             <label class="col-sm-2 text-sm-right">金額</label>
                             <div class="col-sm-8">
                                 <p>{{ $reward->custom_amount }}</p>
                             </div>
                         </div>
                         <div class="row">
-                            <label class="col-sm-2 text-sm-right">支払日</label>
+                            <label class="col-sm-2 text-sm-right">カテゴリ</label>
                             <div class="col-sm-8">
-                                <p>{{ $reward->payment_date ? $reward->payment_date->format('Y-m-d H:i') : '未払い' }}</p>
+                                <p>{{ $reward->category->name }}</p>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">ラベル</label>
+                            <div class="col-sm-8">
+                                <p>{{ $reward->label }}</p>
                             </div>
                         </div>
                     </div>
@@ -81,4 +83,14 @@
             </div>
         </div>
     </div>
+    @stop
+
+    @section('js')
+    <script>
+        $(function() {
+            $('.{{$reward->id}}-delete').click(function(event) {
+                deleteItem('/admin/setting/reward/', '{{$reward->id}}', '/admin/setting/reward');
+            });
+        });
+    </script>
     @stop

--- a/resources/views/vendor/adminlte/master.blade.php
+++ b/resources/views/vendor/adminlte/master.blade.php
@@ -110,6 +110,51 @@
     @endif
     <script src="{{ mix('js/adminApp.js') }}"></script>
 
+    <script>
+        function deleteItem(url, id, redirect) {
+            $.ajaxSetup({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                }
+            });
+            swal.fire({
+                title: "本当に削除しますか？",
+                type: "warning",
+                showCancelButton: true,
+                confirmButtonColor: "#DD6B55",
+                confirmButtonText: "確認",
+                showLoaderOnConfirm: true,
+                allowOutsideClick: false,
+                cancelButtonText: "取消",
+                preConfirm: function() {
+                    $('.swal2-cancel').hide();
+                    return new Promise(function(resolve) {
+                        $.ajax({
+                            method: 'post',
+                            url: url + id,
+                            data: {
+                                _method: 'delete',
+                            },
+                            success: function(data) {
+                                resolve(data);
+                            }
+                        });
+                    });
+                }
+            }).then(function(result) {
+                var data = result.value;
+                if (typeof data === 'object') {
+                    if (data.status) {
+                        swal.fire(data.message, '', 'success');
+                        window.location.href = redirect;
+                    } else {
+                        swal.fire(data.message, '', 'error');
+                    }
+
+                }
+            });
+        }
+    </script>
     {{-- Livewire Script --}}
     @if(config('adminlte.livewire'))
     @if(app()->version() >= 7)

--- a/routes/web.php
+++ b/routes/web.php
@@ -213,6 +213,12 @@ Route::group(['prefix' => 'admin'], function () {
         Route::resource('enterprise', 'EnterpriseController')->except(['create', 'store', 'destroy']);
       });
 
+      Route::group(['prefix' => 'setting'], function () {
+        Route::namespace('Setting')->group(function () {
+          Route::resource('reward', 'RewardController');
+        });
+      });
+
       // Route::get('joblist/index', 'DashboardController@getAlljobs')->name('alljob.get');
       // Route::get('joblist/sort', 'DashboardController@jobsSort')->name('alljob.sort');
       // Route::get('joblist/show/{id}', 'DashboardController@getJobDetail')->name('admin.job.detail');


### PR DESCRIPTION
## Issue
fixed #101

## 内容
- [ ] 運営用管理画面にお祝い金設定機能を追加
　- [ ] 一覧表示、詳細表示、作成、編集、削除

## 動作確認
- [ ] テスト未実装のため、ブラウザによるテスト
- [ ] 該当URL：
　- 運営管理画面 /admin/setting/reward　(運営管理者ログイン必須)