### PR TITLE
運営管理画面に採用報酬の設定機能を実装

### DIFF
--- a/app/Http/Controllers/Admin/Setting/RecruitRewardController.php
+++ b/app/Http/Controllers/Admin/Setting/RecruitRewardController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Setting;
+
+use App\Models\AchievementReward;
+use App\Http\Requests\Admin\Setting\RecruitMent\StoreRecruitRewardRequest;
+use App\Http\Requests\Admin\Setting\RecruitMent\UpdateRecruitRewardRequest;
+use Illuminate\Support\Arr;
+use App\Repositories\CategoryRepository;
+use App\Http\Controllers\Controller;
+use DB;
+
+class RecruitRewardController extends Controller
+{
+    private $categoryRepository;
+
+    public function __construct(CategoryRepository $categoryRepository)
+    {
+        $this->categoryRepository = $categoryRepository;
+    }
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        // $categories = DB::table('categories')->where('slug', 'status')->first()->children();
+        $categories = collect($this->categoryRepository->getCategoriesByslug('status'));
+        $non_attach_categories = $categories->filter(function ($value) {
+            return $value->achievementReward == null;
+        });
+
+        return view('admin.setting.recruit_reward.index', [
+            'rewards' => AchievementReward::orderBy('amount', 'asc')->get(),
+            'non_attach_categories' => $non_attach_categories
+        ]);
+    }
+
+    /**
+     * Create the form for storing the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('admin.setting.recruit_reward.create', [
+            'categories' => $this->categoryRepository->getCategoriesByslug('status')
+        ]);
+    }
+
+    /**
+     * Store the resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreRecruitRewardRequest $request)
+    {
+        AchievementReward::create($request->input('data.RecruitReward'));
+        return redirect()->back()->with('status', '作成しました！');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show(int $id)
+    {
+        return view('admin.setting.recruit_reward.show', [
+            'reward' =>  AchievementReward::find($id)
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(int $id)
+    {
+        return view('admin.setting.recruit_reward.edit', [
+            'reward' => AchievementReward::find($id),
+            'categories' => $this->categoryRepository->getCategoriesByslug('status')
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateRecruitRewardRequest $request, int $id)
+    {
+        $reward = AchievementReward::find($id);
+        $reward->update(Arr::except($request->input('data.RecruitReward'), ['id']));
+
+        return redirect()->back()->with('status', '保存しました！');
+    }
+
+    /**
+     * Delete the specified resource in storage.
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(int $id)
+    {
+        $reward = AchievementReward::find($id);
+        $status = 0;
+
+        // 紐ずくカテゴリが既に求人票と紐付いている場合はエラー返す
+        if ($reward->category->jobitems->isEmpty()) {
+            $reward->delete();
+            $message = '削除しました！';
+            $status = 1;
+        } else {
+            $message = '求人票と紐付いているため削除出来ません！';
+        }
+
+        return response()->json([
+            'message' => $message,
+            'status' => $status,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/Setting/RecruitRewardController.php
+++ b/app/Http/Controllers/Admin/Setting/RecruitRewardController.php
@@ -25,7 +25,6 @@ class RecruitRewardController extends Controller
      */
     public function index()
     {
-        // $categories = DB::table('categories')->where('slug', 'status')->first()->children();
         $categories = collect($this->categoryRepository->getCategoriesByslug('status'));
         $non_attach_categories = $categories->filter(function ($value) {
             return $value->achievementReward == null;
@@ -59,7 +58,7 @@ class RecruitRewardController extends Controller
     public function store(StoreRecruitRewardRequest $request)
     {
         AchievementReward::create($request->input('data.RecruitReward'));
-        return redirect()->back()->with('status', '作成しました！');
+        return redirect()->route('recruit_reward.index')->with('status', '作成しました！');
     }
 
     /**
@@ -101,7 +100,7 @@ class RecruitRewardController extends Controller
         $reward = AchievementReward::find($id);
         $reward->update(Arr::except($request->input('data.RecruitReward'), ['id']));
 
-        return redirect()->back()->with('status', '保存しました！');
+        return redirect()->route('recruit_reward.index')->with('status', '保存しました！');
     }
 
     /**

--- a/app/Http/Controllers/Admin/Setting/RewardController.php
+++ b/app/Http/Controllers/Admin/Setting/RewardController.php
@@ -25,8 +25,14 @@ class RewardController extends Controller
      */
     public function index()
     {
+        $categories = collect($this->categoryRepository->getCategoriesByslug('status'));
+        $non_attach_categories = $categories->filter(function ($value) {
+            return $value->congratsMoney == null;
+        });
+
         return view('admin.setting.reward.index', [
-            'rewards' => CongratsMoney::orderBy('amount', 'asc')->get()
+            'rewards' => CongratsMoney::orderBy('amount', 'asc')->get(),
+            'non_attach_categories' => $non_attach_categories
         ]);
     }
 
@@ -52,7 +58,7 @@ class RewardController extends Controller
     public function store(StoreRewardRequest $request)
     {
         CongratsMoney::create($request->input('data.Reward'));
-        return redirect()->back()->with('status', '作成しました！');
+        return redirect()->route('reward.index')->with('status', '作成しました！');
     }
 
     /**
@@ -94,7 +100,7 @@ class RewardController extends Controller
         $reward = CongratsMoney::find($id);
         $reward->update(Arr::except($request->input('data.Reward'), ['id']));
 
-        return redirect()->back()->with('status', '保存しました！');
+        return redirect()->route('reward.index')->with('status', '保存しました！');
     }
 
     /**

--- a/app/Http/Requests/Admin/Setting/RecruitMent/StoreRecruitRewardRequest.php
+++ b/app/Http/Requests/Admin/Setting/RecruitMent/StoreRecruitRewardRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\RecruitMent;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRecruitRewardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.RecruitReward.amount' => 'required|numeric',
+            'data.RecruitReward.category_id' => 'required|not_in:null|unique:achievement_rewards,category_id|exists:categories,id',
+            'data.RecruitReward.label' => 'nullable|string|max:191',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.RecruitReward.amount' => '金額',
+            'data.RecruitReward.category_id' => 'カテゴリ',
+            'data.RecruitReward.label' => 'ラベル',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Setting/RecruitMent/UpdateRecruitRewardRequest.php
+++ b/app/Http/Requests/Admin/Setting/RecruitMent/UpdateRecruitRewardRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\RecruitMent;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRecruitRewardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.RecruitReward.amount' => 'required|numeric',
+            'data.RecruitReward.category_id' => 'required|not_in:null|unique:achievement_rewards,category_id,' . $this->data['RecruitReward']['id'] . '|exists:categories,id',
+            'data.RecruitReward.label' => 'nullable|string|max:191',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.RecruitReward.amount' => '金額',
+            'data.RecruitReward.category_id' => 'カテゴリ',
+            'data.RecruitReward.label' => 'ラベル',
+        ];
+    }
+}

--- a/app/Models/AchievementReward.php
+++ b/app/Models/AchievementReward.php
@@ -27,7 +27,7 @@ class AchievementReward extends Model
      *
      * @return string
      */
-    public function getCostomAmountAttribute()
+    public function getCustomAmountAttribute()
     {
         return number_format("{$this->amount}") . "円(税別)";
     }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -276,7 +276,7 @@ return [
                 ],
                 [
                     'text' => '採用報酬',
-                    'url'  => '#',
+                    'url'  => 'admin/setting/recruit_reward',
                 ],
                 [
                     'text' => 'カテゴリ',

--- a/resources/views/admin/setting/recruit_reward/create.blade.php
+++ b/resources/views/admin/setting/recruit_reward/create.blade.php
@@ -1,0 +1,93 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | 採用報酬設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>採用報酬設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('recruit_reward.index') }}">採用報酬設定</a></li>
+<li class="breadcrumb-item active">編集</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">作成</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('recruit_reward.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('recruit_reward.store') }}" method="POST" accept-charset="UTF-8">
+                    @csrf
+                    @if(count($errors) > 0)
+                    <div class="alert alert-danger">
+                        <strong><i class="fas fa-exclamation-circle"></i>エラー</strong><br>
+                        <ul class="list-unstyled">
+                            @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endif
+                    <div class="body-box">
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">金額</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="amount" name="data[RecruitReward][amount]" class="form-control" value="{{ old('data.RecruitReward.amount') }}" placeholder="入力　金額" required><span class="mt-1 ml-2">円</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <select class="custom-select" name="data[RecruitReward][category_id]" required>
+                                            <option value="">選択</option>
+                                            @foreach($categories as $category)
+                                            <option value="{{ $category->id }}" @if(old('data.RecruitReward.category_id')===(string) $category->id){{ 'selected' }}@endif>{{ $category->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">ラベル</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="label" name="data[RecruitReward][label]" class="form-control" value="{{ old('data.RecruitReward.label') }}" placeholder="入力　ラベル">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-2">
+                            </div>
+                            <div class="col-md-8 text-right">
+                                <div class="btn-group">
+                                    <button id="admin-submit" type="submit" class="btn btn-primary">作成</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@stop

--- a/resources/views/admin/setting/recruit_reward/edit.blade.php
+++ b/resources/views/admin/setting/recruit_reward/edit.blade.php
@@ -1,0 +1,136 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | 採用報酬設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>採用報酬設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('recruit_reward.index') }}">採用報酬設定</a></li>
+<li class="breadcrumb-item active">編集</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">編集</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('recruit_reward.show', $reward->id) }}" class="btn btn-sm btn-primary" title="編集">
+                            <i class="fa fa-edit"></i><span class="hidden-xs"> 表示</span>
+                        </a>
+                    </div>
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('recruit_reward.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $reward->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('recruit_reward.update', $reward->id) }}" method="POST" accept-charset="UTF-8">
+                    @csrf
+                    @method('PUT')
+                    <input type="hidden" name="data[RecruitReward][id]" value="{{ $reward->id }}">
+                    <div class="form-group">
+                        <div class="system-values">
+                            <div class="system-values-flows">
+                            </div>
+                            <ul class="system-values-list">
+                                <li>
+                                    <p class="system-values-label">ID</p>
+                                    <p class="system-values-item">{{ $reward->id }}</p>
+                                </li>
+                                <li>
+                                    <p class="system-values-label">作成日時</p>
+                                    <p class="system-values-item">{{ $reward->created_at }}</p>
+                                </li>
+                                <li>
+                                    <p class="system-values-label">更新日時</p>
+                                    <p class="system-values-item">{{ $reward->created_at }}</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <hr>
+                    </div>
+                    @if(count($errors) > 0)
+                    <div class="alert alert-danger">
+                        <strong><i class="fas fa-exclamation-circle"></i>エラー</strong><br>
+                        <ul class="list-unstyled">
+                            @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endif
+                    <div class="body-box">
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">金額</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="amount" name="data[RecruitReward][amount]" class="form-control" value="@if(old('data.RecruitReward.amount')){{ old('data.RecruitReward.amount') }}@else{{ $reward->amount ?: '' }}@endif" placeholder="入力　金額" required><span class="mt-1 ml-2">円</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <select class="custom-select" name="data[RecruitReward][category_id]" required>
+                                            @foreach($categories as $category)
+                                            <option value="{{ $category->id }}" @if(old('data.RecruitReward.category_id')===(string) $category->id){{ 'selected' }}@else{{ !old('data.RecruitReward.category_id') && old('data.RecruitReward.category_id') !== '0' && $category->id === $reward->category_id ? 'selected' : ''}}@endif>{{ $category->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">ラベル</label>
+                            <div class="col-sm-8">
+                                <div class="input-group">
+                                    <input type="text" id="label" name="data[RecruitReward][label]" class="form-control" value="@if(old('data.RewRecruitRewardard.label')){{ old('data.RecruitReward.label') }}@else{{ $reward->label ?: '' }}@endif" placeholder="入力　ラベル">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2">
+                        </div>
+                        <div class="col-md-8 text-right">
+                            <div class="btn-group">
+                                <button id="admin-submit" type="submit" class="btn btn-primary">保存</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@stop
+
+@section('js')
+<script>
+    $(function() {
+        $('.{{$reward->id}}-delete').click(function(event) {
+            deleteItem('/admin/setting/recruit_reward/', '{{$reward->id}}', '/admin/setting/recruit_reward');
+        });
+
+    });
+</script>
+@stop

--- a/resources/views/admin/setting/recruit_reward/index.blade.php
+++ b/resources/views/admin/setting/recruit_reward/index.blade.php
@@ -1,0 +1,106 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | 採用報酬設定')
+
+@section('content_header')
+<h1><i class="fas fa-home mr-2"></i>採用報酬設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item active">採用報酬設定</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header with-border">
+                <div class="btn-group float-right">
+                    <a href="{{ route('recruit_reward.create') }}" class="btn btn-sm btn-success">
+                        <i class="fa fa-plus"></i><span class="hidden-xs">&nbsp;&nbsp;新規</span>
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                @if(!$non_attach_categories->isEmpty())
+                <div class="alert alert-warning">
+                    <strong><i class="fas fa-exclamation-circle mb-2"></i>以下のカテゴリに採用報酬が設定されていません</strong><br>
+                    <ul>
+                        @foreach($non_attach_categories as $c)
+                        <li>{{ $c->name }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endif
+                <table id="tableReward" class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>金額</th>
+                            <th>カテゴリ</th>
+                            <th>ラベル</th>
+                            <th>操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if(!$rewards->isEmpty())
+                        @foreach($rewards as $reward)
+                        <tr>
+                            <td>{{ $reward->id }}</td>
+                            <td>{{ $reward->custom_amount }}</td>
+                            <td>{{ $reward->category->name }}</td>
+                            <td>{{ $reward->label }}</td>
+                            <td class="project-actions text-right">
+                                <a class="btn btn-primary btn-sm" href="{{ route('recruit_reward.show', $reward->id) }}">
+                                    <i class="fas fa-eye">
+                                    </i>
+                                </a>
+                                <a class="btn btn-info btn-sm" href="{{ route('recruit_reward.edit', $reward->id) }}">
+                                    <i class="fas fa-pencil-alt">
+                                    </i>
+                                </a>
+                                <a href="javascript:void(0);" class="btn btn-danger btn-sm grid-row-delete" data-id="{{ $reward->id }}" data-toggle="tooltip" title="" data-original-title="削除">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        @endforeach
+                        @else
+                        <p>データがありません</p>
+                        @endif
+
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+@stop
+
+@section('js')
+<script>
+    $(function() {
+        $('#tableReward').DataTable({
+            "paging": true,
+            "searching": true,
+            "scrollX": true,
+            "ordering": false,
+            "lengthMenu": [10, 20, 30, 40, 50, 100],
+            "displayLength": 50,
+            "info": true,
+            "autoWidth": false,
+            "responsive": true,
+            "columnDefs": [{
+                "targets": 'nosort',
+                "orderable": false
+            }]
+        });
+
+        $('.grid-row-delete').unbind('click').click(function() {
+            let id = $(this).data('id');
+            deleteItem('/admin/setting/recruit_reward/', id, '/admin/setting/recruit_reward');
+        });
+
+    });
+</script>
+@stop

--- a/resources/views/admin/setting/recruit_reward/show.blade.php
+++ b/resources/views/admin/setting/recruit_reward/show.blade.php
@@ -1,0 +1,96 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | 採用報酬設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>採用報酬設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('recruit_reward.index') }}">採用報酬設定</a></li>
+<li class="breadcrumb-item active">詳細</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">詳細</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('recruit_reward.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('recruit_reward.edit', $reward->id) }}" class="btn btn-sm btn-primary" title="編集">
+                            <i class="fa fa-edit"></i><span class="hidden-xs"> 編集</span>
+                        </a>
+                    </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $reward->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="form-group">
+                    <div class="system-values">
+                        <div class="system-values-flows">
+                        </div>
+                        <ul class="system-values-list">
+                            <li>
+                                <p class="system-values-label">ID</p>
+                                <p class="system-values-item">{{ $reward->id }}</p>
+                            </li>
+                            <li>
+                                <p class="system-values-label">作成日時</p>
+                                <p class="system-values-item">{{ $reward->created_at }}</p>
+                            </li>
+                            <li>
+                                <p class="system-values-label">更新日時</p>
+                                <p class="system-values-item">{{ $reward->created_at }}</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <hr>
+                </div>
+                <div class="body-box">
+                    <div class="form-group">
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">金額</label>
+                            <div class="col-sm-8">
+                                <p>{{ $reward->custom_amount }}</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">カテゴリ</label>
+                            <div class="col-sm-8">
+                                <p>{{ $reward->category->name }}</p>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">ラベル</label>
+                            <div class="col-sm-8">
+                                <p>{{ $reward->label }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    @stop
+
+    @section('js')
+    <script>
+        $(function() {
+            $('.{{$reward->id}}-delete').click(function(event) {
+                deleteItem('/admin/setting/recruit_reward/', '{{$reward->id}}', '/admin/setting/recruit_reward');
+            });
+        });
+    </script>
+    @stop

--- a/resources/views/admin/setting/reward/index.blade.php
+++ b/resources/views/admin/setting/reward/index.blade.php
@@ -22,6 +22,16 @@
                 </div>
             </div>
             <div class="card-body">
+                @if(!$non_attach_categories->isEmpty())
+                <div class="alert alert-warning">
+                    <strong><i class="fas fa-exclamation-circle mb-2"></i>以下のカテゴリにお祝い金が設定されていません</strong><br>
+                    <ul>
+                        @foreach($non_attach_categories as $c)
+                        <li>{{ $c->name }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endif
                 <table id="tableReward" class="table table-bordered">
                     <thead>
                         <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -216,6 +216,7 @@ Route::group(['prefix' => 'admin'], function () {
       Route::group(['prefix' => 'setting'], function () {
         Route::namespace('Setting')->group(function () {
           Route::resource('reward', 'RewardController');
+          Route::resource('recruit_reward', 'RecruitRewardController');
         });
       });
 


### PR DESCRIPTION
## Issue
fixed  #114 

## 内容
- [ ] 運営用管理画面に採用報酬設定機能を追加
　- [ ] 一覧表示、詳細表示、作成、編集、削除
　- [ ] カテゴリと紐づいていなデータがあれば、アラートを表示

## 動作確認
- [ ] テスト未実装のため、ブラウザによるテスト
- [ ] 該当URL： /admin/setting/recruit_reward　(運営管理者ログイン必須)
