### PR TITLE
運営用管理画面にカテゴリ設定機能を実装

### DIFF
--- a/app/Http/Controllers/Admin/Setting/CategoryController.php
+++ b/app/Http/Controllers/Admin/Setting/CategoryController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Setting;
+
+use App\Models\Category;
+use Illuminate\Http\Request;
+use App\Http\Requests\Admin\Setting\Category\StoreCategoryRequest;
+use App\Http\Requests\Admin\Setting\Category\UpdateCategoryRequest;
+use Illuminate\Support\Arr;
+use App\Repositories\CategoryRepository;
+use App\Http\Controllers\Controller;
+
+class CategoryController extends Controller
+{
+    private $categoryRepository;
+
+    public function __construct(CategoryRepository $categoryRepository)
+    {
+        $this->categoryRepository = $categoryRepository;
+    }
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('admin.setting.category.index', [
+            'categories' => $this->categoryRepository->getCategories()
+        ]);
+    }
+
+    /**
+     * Create the form for storing the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('admin.setting.category.create', [
+            'categories' => $this->categoryRepository->getCategories()
+        ]);
+    }
+
+    /**
+     * Store the resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreCategoryRequest $request)
+    {
+
+        $data = $request->input('data.Category');
+        $parent = Category::find($data['parent_id']);
+
+        if ($parent->slug == 'salary' && isset($data['sub_parent_id'])) {
+            $parent = Category::find($data['sub_parent_id']);
+        }
+
+        if ($parent->slug == null) return redirect()->back();
+
+        $parent->children()->create(Arr::except($data, ['parent_id', 'sub_parent_id']));
+
+        return redirect()->route('category.index')->with('status', '作成しました！');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show(int $id)
+    {
+        return view('admin.setting.category.show', [
+            'category' =>  Category::withDepth()->find($id)
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(int $id)
+    {
+        return view('admin.setting.category.edit', [
+            'category' => Category::find($id),
+            'categories' => $this->categoryRepository->getCategories()
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateCategoryRequest $request, int $id)
+    {
+        $category = Category::find($id);
+        $category->update($request->input('data.Category'));
+
+        return redirect()->route('category.index')->with('status', '保存しました！');
+    }
+
+    /**
+     * Delete the specified resource in storage.
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(int $id)
+    {
+        $category = Category::find($id);
+        $status = 0;
+
+        // カテゴリが既に求人票と紐付いている場合はエラー返す
+        if ($category->jobitems->isEmpty()) {
+            $category->delete();
+            $message = '削除しました！';
+            $status = 1;
+        } else {
+            $message = '求人票と紐付いているため削除出来ません！ee';
+        }
+
+        return response()->json([
+            'message' => $message,
+            'status' => $status,
+        ]);
+    }
+}

--- a/app/Http/Requests/Admin/Setting/Category/StoreCategoryRequest.php
+++ b/app/Http/Requests/Admin/Setting/Category/StoreCategoryRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\Category;
+
+use App\Models\Category;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.Category.name' => 'required|string|max:191',
+            'data.Category.parent_id' => 'required|not_in:null|exists:categories,id',
+            'data.Category.sub_parent_id' => 'nullable|exists:categories,id',
+            'data.Category.sort' => 'required|numeric',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.Category.name' => 'カテゴリ名',
+            'data.Category.parent_id' => '親カテゴリ',
+            'data.Category.sub_parent_id' => 'サブ親カテゴリ',
+            'data.Category.sort' => '並び順',
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->sometimes('data.Category.sub_parent_id', 'required|not_in:null', function ($input) {
+            $parent = Category::find($input['data']['Category']['parent_id']);
+            return $parent->slug == 'salary';
+        });
+    }
+}

--- a/app/Http/Requests/Admin/Setting/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Admin/Setting/Category/UpdateCategoryRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Admin\Setting\Category;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data.Category.name' => 'required|string|max:191',
+            'data.Category.sort' => 'required|numeric',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'data.Category.name' => 'カテゴリ名',
+            'data.Category.sort' => '並び順',
+        ];
+    }
+}

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -14,7 +14,7 @@ class CategoryRepository extends AbstractRepository
 
     public function getCategories(): Collection
     {
-        return Category::where('slug', '!=', 'unregistered')->orWhereNull('slug')->get()->toTree();
+        return Category::withDepth()->where('slug', '!=', 'unregistered')->orWhereNull('slug')->get()->toTree();
     }
 
     public function getCategoriesByslug(string $parentSlug, string $childSlug = ''): array

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -280,7 +280,7 @@ return [
                 ],
                 [
                     'text' => 'カテゴリ',
-                    'url'  => '#',
+                    'url'  => 'admin/setting/category',
                 ],
             ],
         ],

--- a/public/js/adminApp.js
+++ b/public/js/adminApp.js
@@ -28214,6 +28214,13 @@ module.exports = function(module) {
       }
     });
     jQuery.datetimepicker.setLocale('ja');
+    $("form").submit(function () {
+      var self = this;
+      $(":submit", self).prop("disabled", true);
+      setTimeout(function () {
+        $(":submit", self).prop("disabled", false);
+      }, 10000);
+    });
 
     if ($('#start_specified_date').length && $('#end_specified_date').length) {
       var start_specified_date = $('#start_specified_date'),

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/adminApp.js": "/js/adminApp.js?id=09f0996f2d928206c603",
+    "/js/adminApp.js": "/js/adminApp.js?id=705cee3a245815fda385",
     "/js/app.js": "/js/app.js?id=aebde5f756bff2603e49",
     "/css/app.css": "/css/app.css?id=f14783838c9dcf1c29e7",
     "/css/adminApp.css": "/css/adminApp.css?id=7fec90df55a533c3838f"

--- a/resources/js/admin/common.js
+++ b/resources/js/admin/common.js
@@ -8,6 +8,14 @@
         });
         jQuery.datetimepicker.setLocale('ja');
 
+        $("form").submit(function () {
+            var self = this;
+            $(":submit", self).prop("disabled", true);
+            setTimeout(function () {
+                $(":submit", self).prop("disabled", false);
+            }, 10000);
+        });
+
         if ($('#start_specified_date').length && $('#end_specified_date').length) {
             var start_specified_date = $('#start_specified_date'),
                 end_specified_date = $('#end_specified_date');

--- a/resources/views/admin/setting/category/create.blade.php
+++ b/resources/views/admin/setting/category/create.blade.php
@@ -1,0 +1,141 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | カテゴリ設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>カテゴリ設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('category.index') }}">カテゴリ設定</a></li>
+<li class="breadcrumb-item active">編集</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">作成</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('category.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('category.store') }}" method="POST" accept-charset="UTF-8">
+                    @csrf
+                    @if(count($errors) > 0)
+                    <div class="alert alert-danger">
+                        <strong><i class="fas fa-exclamation-circle"></i>エラー</strong><br>
+                        <ul class="list-unstyled">
+                            @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endif
+                    <div class="body-box">
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ名</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="amount" name="data[Category][name]" class="form-control" value="{{ old('data.Category.name') }}" placeholder="入力　カテゴリ名" required>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">親カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div>
+                                        <select class="custom-select parent" name="data[Category][parent_id]" required>
+                                            <option value="">選択</option>
+                                            @foreach($categories as $category)
+                                            <option value="{{ $category->id }}" class="{{ $category->slug == 'salary' ? 'salary' : '' }}" @if(old('data.Category.parent_id')===(string) $category->id){{ 'selected' }}@endif>{{ $category->name }}</option>
+                                            @endforeach
+                                        </select>
+                                        <select class="custom-select mt-2 children" name="data[Category][sub_parent_id]">
+                                            <option value="">選択</option>
+                                            @foreach($categories->where('slug', 'salary')->first()->children as $category)
+                                            <option value="{{ $category->id }}" @if(old('data.Category.sub_parent_id')===(string) $category->id){{ 'selected' }}@endif data-val="{{ $category->parent->id }}">{{ $category->name }}</option>
+                                            @endforeach
+                                        </select>
+                                        <input type="hidden" value="{{ $categories->where('slug', 'salary')->first()->id }}" id="parent_salary_id">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">ソート</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="label" name="data[Category][sort]" class="form-control" value="{{ old('data.Category.sort') }}" placeholder="入力　ソート">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-2">
+                            </div>
+                            <div class="col-md-8 text-right">
+                                <div class="btn-group">
+                                    <button id="admin-submit" type="submit" class="btn btn-primary">作成</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@stop
+
+@section('js')
+<script>
+    $(function() {
+        let $parent = $('.parent');
+        let parentSalaryId = $('#parent_salary_id').val();
+        let $children = $('.children');
+        let isSalary = false;
+
+        if ($parent.val() == parentSalaryId) isSalary = true;
+
+        $('.parent').change(function() {
+            let val1 = $(this).val();
+            $children.find('option').each(function() {
+                let val2 = $(this).data('val');
+                isSalary = true;
+                if (val1 != val2) {
+                    $(this).attr('selected', false)
+                    isSalary = false;
+                }
+            });
+
+            if (isSalary) {
+                $children.show();
+                $children.prop('required', true);
+            } else {
+                $children.hide();
+                $children.prop('required', false);
+            }
+
+        });
+        if (isSalary) {
+            $children.show();
+            $children.prop('required', true);
+        } else {
+            $children.hide();
+            $children.prop('required', false);
+        }
+    });
+</script>
+@stop

--- a/resources/views/admin/setting/category/edit.blade.php
+++ b/resources/views/admin/setting/category/edit.blade.php
@@ -1,0 +1,137 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | カテゴリ設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>カテゴリ設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('category.index') }}">カテゴリ設定</a></li>
+<li class="breadcrumb-item active">編集</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">編集</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('category.show', $category->id) }}" class="btn btn-sm btn-primary" title="編集">
+                            <i class="fa fa-edit"></i><span class="hidden-xs"> 表示</span>
+                        </a>
+                    </div>
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('category.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $category->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('category.update', $category->id) }}" method="POST" accept-charset="UTF-8">
+                    @csrf
+                    @method('PUT')
+                    <div class="form-group">
+                        <div class="system-values">
+                            <div class="system-values-flows">
+                            </div>
+                            <ul class="system-values-list">
+                                <li>
+                                    <p class="system-values-label">ID</p>
+                                    <p class="system-values-item">{{ $category->id }}</p>
+                                </li>
+                                <li>
+                                    <p class="system-values-label">作成日時</p>
+                                    <p class="system-values-item">{{ $category->created_at }}</p>
+                                </li>
+                                <li>
+                                    <p class="system-values-label">更新日時</p>
+                                    <p class="system-values-item">{{ $category->created_at }}</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <hr>
+                    </div>
+                    @if(count($errors) > 0)
+                    <div class="alert alert-danger">
+                        <strong><i class="fas fa-exclamation-circle"></i>エラー</strong><br>
+                        <ul class="list-unstyled">
+                            @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endif
+                    <div class="body-box">
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">カテゴリ名</label>
+                                <div class="col-sm-8">
+                                    <div class="input-group">
+                                        <input type="text" id="name" name="data[Category][name]" class="form-control" value="@if(old('data.Category.name')){{ old('data.Category.name') }}@else{{ $category->name ?: '' }}@endif" placeholder="入力　カテゴリ名" required>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="row">
+                                <label class="col-sm-2 text-sm-right">親カテゴリ</label>
+                                <div class="col-sm-8">
+                                    <div>
+                                        @if($category->ancestors->isEmpty())
+                                        なし
+                                        @else
+                                        {{ $category->parent->name }}
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @if($category->children->isEmpty())
+                    <div class="form-group">
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">ソート</label>
+                            <div class="col-sm-8">
+                                <div class="input-group">
+                                    <input type="text" id="label" name="data[Category][sort]" class="form-control" value="@if(old('data.Category.sort')){{ old('data.Category.sort') }}@else{{ $category->sort ?: '' }}@endif" placeholder="入力　ソート">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @else
+                    <input type="hidden" name="data[Category][sort]" class="form-control" value="0">
+                    @endif
+                    <div class="row">
+                        <div class="col-md-2">
+                        </div>
+                        <div class="col-md-8 text-right">
+                            <div class="btn-group">
+                                <button id="admin-submit" type="submit" class="btn btn-primary">保存</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@stop
+
+@section('js')
+<script>
+    $(function() {
+        $('.{{$category->id}}-delete').click(function(event) {
+            deleteItem('/admin/setting/category/', '{{$category->id}}', '/admin/setting/category');
+        });
+    });
+</script>
+@stop

--- a/resources/views/admin/setting/category/index.blade.php
+++ b/resources/views/admin/setting/category/index.blade.php
@@ -1,0 +1,137 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | カテゴリ設定')
+
+@section('content_header')
+<h1><i class="fas fa-home mr-2"></i>カテゴリ設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item active">カテゴリ設定</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header with-border">
+                <div class="btn-group float-right">
+                    <a href="{{ route('category.create') }}" class="btn btn-sm btn-success">
+                        <i class="fa fa-plus"></i><span class="hidden-xs">&nbsp;&nbsp;新規</span>
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                <table id="tableCategory" class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>名前</th>
+                            <th>並び順</th>
+                            <th>操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if(!$categories->isEmpty())
+                        @foreach($categories as $category)
+                        <tr>
+                            <td>{{ $category->id }}</td>
+                            <td class="font-weight-bold">{{ $category->name }}</td>
+                            <td></td>
+                            <td class="project-actions text-right">
+                                <a class="btn btn-primary btn-sm" href="{{ route('category.show', $category->id) }}">
+                                    <i class="fas fa-eye">
+                                    </i>
+                                </a>
+                                <a class="btn btn-info btn-sm" href="{{ route('category.edit', $category->id) }}">
+                                    <i class="fas fa-pencil-alt">
+                                    </i>
+                                </a>
+                                <a href="javascript:void(0);" class="btn btn-danger btn-sm grid-row-delete" data-id="{{ $category->id }}" data-toggle="tooltip" title="" data-original-title="削除">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        @if($category->children)
+                        @foreach($category->children->sortBy('sort') as $children)
+                        <tr>
+                            <td>{{ $children->id }}</td>
+                            <td>ー {{ $children->name }}</td>
+                            <td>{{ $children->children->isEmpty() ? $children->sort : '' }}</td>
+                            <td class="project-actions text-right">
+                                <a class="btn btn-primary btn-sm" href="{{ route('category.show', $children->id) }}">
+                                    <i class="fas fa-eye">
+                                    </i>
+                                </a>
+                                <a class="btn btn-info btn-sm" href="{{ route('category.edit', $children->id) }}">
+                                    <i class="fas fa-pencil-alt">
+                                    </i>
+                                </a>
+                                <a href="javascript:void(0);" class="btn btn-danger btn-sm grid-row-delete" data-id="{{ $children->id }}" data-toggle="tooltip" title="" data-original-title="削除">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        @if($children->children)
+                        @foreach($children->children->sortBy('sort') as $c)
+                        <tr>
+                            <td>{{ $c->id }}</td>
+                            <td>ーー {{ $c->name }}</td>
+                            <td>{{ $c->children->isEmpty() ? $c->sort : '' }}</td>
+                            <td class="project-actions text-right">
+                                <a class="btn btn-primary btn-sm" href="{{ route('category.show', $c->id) }}">
+                                    <i class="fas fa-eye">
+                                    </i>
+                                </a>
+                                <a class="btn btn-info btn-sm" href="{{ route('category.edit', $c->id) }}">
+                                    <i class="fas fa-pencil-alt">
+                                    </i>
+                                </a>
+                                <a href="javascript:void(0);" class="btn btn-danger btn-sm grid-row-delete" data-id="{{ $c->id }}" data-toggle="tooltip" title="" data-original-title="削除">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        @endforeach
+                        @endif
+                        @endforeach
+                        @endif
+                        @endforeach
+                        @else
+                        <p>データがありません</p>
+                        @endif
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+@stop
+
+@section('js')
+<script>
+    $(function() {
+        $('#tableCategory').DataTable({
+            "paging": true,
+            "searching": true,
+            "scrollX": true,
+            "ordering": false,
+            "lengthMenu": [50, 100, 200, 300],
+            "displayLength": 100,
+            "info": true,
+            "autoWidth": false,
+            "responsive": true,
+            "columnDefs": [{
+                "targets": 'nosort',
+                "orderable": false
+            }]
+        });
+
+        $('.grid-row-delete').unbind('click').click(function() {
+            let id = $(this).data('id');
+            deleteItem('/admin/setting/category/', id, '/admin/setting/category');
+        });
+
+    });
+</script>
+@stop

--- a/resources/views/admin/setting/category/show.blade.php
+++ b/resources/views/admin/setting/category/show.blade.php
@@ -1,0 +1,102 @@
+@extends('adminlte::page')
+
+@section('title', 'JOB CiNEMA | カテゴリ設定')
+
+@section('content_header')
+<h1><i class="fas fa-edit mr-2"></i>カテゴリ設定</h1>
+@stop
+
+@section('content_bread')
+<li class="breadcrumb-item"><a href="{{ route('category.index') }}">カテゴリ設定</a></li>
+<li class="breadcrumb-item active">詳細</li>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">詳細</h3>
+                <div class="card-tools">
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('category.index') }}" class="btn btn-sm btn-default" title="一覧">
+                            <i class="fa fa-list"></i><span class="hidden-xs"> 一覧</span>
+                        </a>
+                    </div>
+                    <div class="btn-group" style="margin-right: 5px">
+                        <a href="{{ route('category.edit', $category->id) }}" class="btn btn-sm btn-primary" title="編集">
+                            <i class="fa fa-edit"></i><span class="hidden-xs"> 編集</span>
+                        </a>
+                    </div>
+                    <div class="btn-group pull-right" style="margin-right: 5px">
+                        <a href="javascript:void(0);" class="btn btn-sm btn-danger {{ $category->id }}-delete" title="削除">
+                            <i class="fa fa-trash"></i><span class="hidden-xs"> 削除</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="form-group">
+                    <div class="system-values">
+                        <div class="system-values-flows">
+                        </div>
+                        <ul class="system-values-list">
+                            <li>
+                                <p class="system-values-label">ID</p>
+                                <p class="system-values-item">{{ $category->id }}</p>
+                            </li>
+                            <li>
+                                <p class="system-values-label">作成日時</p>
+                                <p class="system-values-item">{{ $category->created_at }}</p>
+                            </li>
+                            <li>
+                                <p class="system-values-label">更新日時</p>
+                                <p class="system-values-item">{{ $category->created_at }}</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <hr>
+                </div>
+                <div class="body-box">
+                    <div class="form-group">
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">カテゴリ名</label>
+                            <div class="col-sm-8">
+                                <p>{{ $category->name }}</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">親カテゴリ</label>
+                            <div class="col-sm-8">
+                                <p>{{ $category->parent ? $category->parent->name : 'なし' }}</p>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">ソート</label>
+                            <div class="col-sm-8">
+                                <p>{{ $category->sort }}</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <label class="col-sm-2 text-sm-right">階層</label>
+                            <div class="col-sm-8">
+                                <p>{{ $category->depth }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    @stop
+
+    @section('js')
+    <script>
+        $(function() {
+            $('.{{$category->id}}-delete').click(function(event) {
+                deleteItem('/admin/setting/category/', '{{$category->id}}', '/admin/setting/category');
+            });
+        });
+    </script>
+    @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -217,6 +217,7 @@ Route::group(['prefix' => 'admin'], function () {
         Route::namespace('Setting')->group(function () {
           Route::resource('reward', 'RewardController');
           Route::resource('recruit_reward', 'RecruitRewardController');
+          Route::resource('category', 'CategoryController');
         });
       });
 


### PR DESCRIPTION
## Issue
fixed #116 

## 内容
- [ ] 運営用管理画面にカテゴリ設定機能を追加
　- [ ] 一覧表示、詳細表示、作成、編集、削除

## 動作確認
- [ ] テスト未実装のため、ブラウザによるテスト
- [ ] 該当URL： /admin/setting/category　(運営管理者ログイン必須)
